### PR TITLE
feat(text-search-engine): ✨ new option strictnessCoefficient for controlling if hitRange is expected

### DIFF
--- a/.changeset/old-tips-sleep.md
+++ b/.changeset/old-tips-sleep.md
@@ -1,0 +1,5 @@
+---
+'text-search-engine': minor
+---
+
+new option strictnessCoefficient for controlling if hitRange is expected

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,7 +12,7 @@ const scopes = fg
 module.exports = {
 	extends: ['@commitlint/config-conventional'],
 	rules: {
-		'limit-description-length': [2, 'always', 120],
+		'header-max-length': [2, 'always', 120],
 		'scope-enum': [2, 'always', scopes],
 	},
 	prompt: {

--- a/packages/text-search-engine/src/__test__/search.spec.ts
+++ b/packages/text-search-engine/src/__test__/search.spec.ts
@@ -82,4 +82,22 @@ describe('search', () => {
 		])
 		expect(search(source_1, 'meyinyon', { mergeSpaces: true })).toEqual([[4, 8]])
 	})
+
+	test('strictnessCoefficient should work within search', () => {
+		const source_1 = 'Node.js 最强监控平台 V8'
+		expect(search(source_1, 'nozjk')).toEqual([
+			[0, 1],
+			[8, 8],
+			[10, 11],
+		])
+
+		// 当 strictnessCoefficient 为 0.5 时，nozjk 为 五个字符， Math.ceil(5 * 0.5) = 3， 命中小于等于 3 个字符时正常返回
+		expect(search(source_1, 'nozjk', { strictnessCoefficient: 0.5 })).toEqual([
+			[0, 1],
+			[8, 8],
+			[10, 11],
+		])
+
+		expect(search(source_1, 'nozjk', { strictnessCoefficient: 0.4 })).toEqual(undefined)
+	})
 })

--- a/packages/text-search-engine/src/exports.ts
+++ b/packages/text-search-engine/src/exports.ts
@@ -34,16 +34,17 @@ export function pureSearch(source: string, target: string, option: SearchOptionW
 
 	if (!rawHitRanges) return undefined
 	const hitRangesByMergedSpaces = option.mergeSpaces ? mergeSpacesWithRanges(_source, rawHitRanges) : rawHitRanges
-	// filter by strictness
-	return option.strictness
-		? isStrictnessSatisfied(option.strictness, hitRangesByMergedSpaces)
+
+	return option.strictnessCoefficient
+		? isStrictnessSatisfied(option.strictnessCoefficient, _target, hitRangesByMergedSpaces)
 			? hitRangesByMergedSpaces
 			: undefined
 		: hitRangesByMergedSpaces
 }
 
 /**
- * return the highlighted string if there is a match
+ * returns the highlighted string, which needs to be printed using console.log
+ * 返回高亮后的字符串，需要用 console.log 打印
  * @param source required, the source string you want to search
  * @param target required, the string by user input. generally speaking, it's length should be less than `source`, otherwise the result will be undefined
  * @param option optional, the default value is `{}`
@@ -54,7 +55,8 @@ export function highlightMatches(source: string, target: string, _option: Search
 }
 
 /**
- * return the highlighted string if there is a match
+ * returns the highlighted string without the preset Pinyin collection, which needs to be printed using console.log
+ * 在没有预设拼音集合的情况下搜索并返回高亮后的字符串，需要用 console.log 打印
  * @param source required, the source string you want to search
  * @param target required, the string by user input. generally speaking, it's length should be less than `source`, otherwise the result will be undefined
  * @param option optional, the default value is `{}`

--- a/packages/text-search-engine/src/index.ts
+++ b/packages/text-search-engine/src/index.ts
@@ -4,5 +4,5 @@ export {
 	highlightMatches,
 } from './exports'
 export { searchSentenceByBoundaryMapping } from './search'
-export { mergeSpacesWithRanges } from './utils'
+export { mergeSpacesWithRanges, isStrictnessSatisfied } from './utils'
 export * from './types'

--- a/packages/text-search-engine/src/pure.ts
+++ b/packages/text-search-engine/src/pure.ts
@@ -4,5 +4,5 @@ export {
 	pureHighlightMatches,
 } from './exports'
 export { searchSentenceByBoundaryMapping } from './search'
-export { mergeSpacesWithRanges } from './utils'
+export { mergeSpacesWithRanges, isStrictnessSatisfied } from './utils'
 export * from './types'

--- a/packages/text-search-engine/src/react/highlight.tsx
+++ b/packages/text-search-engine/src/react/highlight.tsx
@@ -63,6 +63,8 @@ export interface HighlightWithRangesProps {
 
 const composeStyle = (style: React.CSSProperties, className: string) => ({ style, className })
 
+const replaceSpace = (text: string) => text.replace(/ /g, '\u00A0')
+
 export const HighlightWithRanges: React.FC<HighlightWithRangesProps> = ({
 	source,
 	id,
@@ -99,28 +101,25 @@ export const HighlightWithRanges: React.FC<HighlightWithRangesProps> = ({
 
 		for (const [start, end] of hitRanges.sort((a, b) => a[0] - b[0])) {
 			if (start > lastIndex) {
-				const normalText = source.slice(lastIndex, start)
 				newContent.push(
 					<div key={`${uuid}-normal-${lastIndex}`} {..._normalStyle}>
-						{normalText}
+						{replaceSpace(source.slice(lastIndex, start))}
 					</div>
 				)
 			}
 
-			const highlightText = source.slice(start, end + 1)
 			newContent.push(
 				<div key={`${uuid}-highlight-${start}`} {..._highlightStyle}>
-					{highlightText}
+					{replaceSpace(source.slice(start, end + 1))}
 				</div>
 			)
 			lastIndex = end + 1
 		}
 
 		if (lastIndex < source.length) {
-			const remainingText = source.slice(lastIndex)
 			newContent.push(
 				<div key={`${uuid}-normal-${lastIndex}`} {..._normalStyle}>
-					{remainingText}
+					{replaceSpace(source.slice(lastIndex))}
 				</div>
 			)
 		}

--- a/packages/text-search-engine/src/types.ts
+++ b/packages/text-search-engine/src/types.ts
@@ -8,17 +8,11 @@ export interface SourceMappingData {
 	originalLength: number
 }
 
-export enum StrictnessLevel {
-	strict = 'strict',
-	lenient = 'lenient',
-}
-
-export type StrictnessLevelTypes = keyof typeof StrictnessLevel
-
 export interface SearchOption {
 	strictCase?: boolean
 	mergeSpaces?: boolean
-	strictness?: StrictnessLevelTypes
+	// (0, 1]
+	strictnessCoefficient?: number
 }
 
 export interface SearchOptionWithPinyin extends SearchOption {

--- a/packages/text-search-engine/src/types.ts
+++ b/packages/text-search-engine/src/types.ts
@@ -8,9 +8,17 @@ export interface SourceMappingData {
 	originalLength: number
 }
 
+export enum StrictnessLevel {
+	strict = 'strict',
+	lenient = 'lenient',
+}
+
+export type StrictnessLevelTypes = keyof typeof StrictnessLevel
+
 export interface SearchOption {
 	strictCase?: boolean
 	mergeSpaces?: boolean
+	strictness?: StrictnessLevelTypes
 }
 
 export interface SearchOptionWithPinyin extends SearchOption {

--- a/packages/text-search-engine/src/utils.ts
+++ b/packages/text-search-engine/src/utils.ts
@@ -1,4 +1,4 @@
-import { type Matrix, StrictnessLevel, type StrictnessLevelTypes, type StrictnessType } from './types'
+import type { Matrix } from './types'
 
 export function getHighlightText(str: string) {
 	return `\x1b[32m${str}\x1b[0m`
@@ -93,16 +93,7 @@ export function mergeSpacesWithRanges(source: string, rawHitRanges: Matrix) {
 	return hitRanges
 }
 
-const CoefficientMap = {
-	[StrictnessLevel.strict]: 0.8,
-	[StrictnessLevel.lenient]: 0.5,
-}
-
-export function isStrictnessSatisfied(strictness: StrictnessLevelTypes, target: string, rawHitRanges: Matrix) {
-	const coefficient = CoefficientMap[strictness]
-	// todo refine the hit length calculation
-	const hitLength = rawHitRanges.length
-	const targetLength = target.length
-
-	return hitLength / targetLength >= coefficient
+export function isStrictnessSatisfied(strictnessCoefficient: number, target: string, rawHitRanges: Matrix) {
+	const maxHitLength = Math.ceil(Math.abs(strictnessCoefficient) * target.length)
+	return maxHitLength >= rawHitRanges.length
 }

--- a/packages/text-search-engine/src/utils.ts
+++ b/packages/text-search-engine/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Matrix } from './types'
+import { type Matrix, StrictnessLevel, type StrictnessLevelTypes, type StrictnessType } from './types'
 
 export function getHighlightText(str: string) {
 	return `\x1b[32m${str}\x1b[0m`
@@ -91,4 +91,18 @@ export function mergeSpacesWithRanges(source: string, rawHitRanges: Matrix) {
 		lastEnd = end
 	}
 	return hitRanges
+}
+
+const CoefficientMap = {
+	[StrictnessLevel.strict]: 0.8,
+	[StrictnessLevel.lenient]: 0.5,
+}
+
+export function isStrictnessSatisfied(strictness: StrictnessLevelTypes, target: string, rawHitRanges: Matrix) {
+	const coefficient = CoefficientMap[strictness]
+	// todo refine the hit length calculation
+	const hitLength = rawHitRanges.length
+	const targetLength = target.length
+
+	return hitLength / targetLength >= coefficient
 }


### PR DESCRIPTION
```js
const source_1 = 'Node.js 最强监控平台 V8'
expect(search(source_1, 'nozjk')).toEqual([
  [0, 1],
  [8, 8],
  [10, 11],
])

// 当 strictnessCoefficient 为 0.5 时，nozjk 为 五个字符， Math.ceil(5 * 0.5) = 3， 命中小于等于 3 个字符时正常返回
expect(search(source_1, 'nozjk', { strictnessCoefficient: 0.5 })).toEqual([
  [0, 1],
  [8, 8],
  [10, 11],
])

expect(search(source_1, 'nozjk', { strictnessCoefficient: 0.4 })).toEqual(undefined)
```