### PR TITLE
fix(text-search-engine): bug fix searchWithIndexOf function

### DIFF
--- a/.changeset/polite-carpets-cross.md
+++ b/.changeset/polite-carpets-cross.md
@@ -1,0 +1,5 @@
+---
+'text-search-engine': patch
+---
+
+fix searchWithIndexof funtion to remove target.trim()

--- a/.changeset/polite-carpets-cross.md
+++ b/.changeset/polite-carpets-cross.md
@@ -2,4 +2,4 @@
 'text-search-engine': patch
 ---
 
-fix searchWithIndexof funtion to remove target.trim()
+fix searchWithIndexOf function to remove target.trim()

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "bun",
+			"internalConsoleOptions": "neverOpen",
+			"request": "launch",
+			"name": "Debug File",
+			"program": "${file}",
+			"cwd": "${workspaceFolder}",
+			"stopOnEntry": false,
+			"watchMode": false
+		},
+		{
+			"type": "bun",
+			"internalConsoleOptions": "neverOpen",
+			"request": "attach",
+			"name": "Attach Bun",
+			"url": "ws://localhost:6499/",
+			"stopOnEntry": false
+		}
+	]
+}

--- a/packages/text-search-engine/src/__test__/search.spec.ts
+++ b/packages/text-search-engine/src/__test__/search.spec.ts
@@ -1,6 +1,6 @@
 import { extractBoundaryMapping } from '../boundary'
 import { search } from '../exports'
-import { searchByBoundaryMapping, searchWithIndexof } from '../search'
+import { searchByBoundaryMapping, searchWithIndexOf } from '../search'
 
 describe('search', () => {
 	test('searchByBoundaryMapping should work', () => {
@@ -101,11 +101,11 @@ describe('search', () => {
 		expect(search(source_1, 'nozjk', { strictnessCoefficient: 0.4 })).toEqual(undefined)
 	})
 
-	test('searchWithIndexof should work', () => {
+	test('searchWithIndexOf should work', () => {
 		const source_1 = 'nodejs 123ab ss'
-		expect(searchWithIndexof(source_1, 'nodejs')).toEqual([[0, 5]])
-		expect(searchWithIndexof(source_1, 'nodejs ')).toEqual([[0, 6]])
-		expect(searchWithIndexof(source_1, 'nodejs  ')).toEqual(0)
-		expect(searchWithIndexof(source_1, 'js12bss')).toEqual(0)
+		expect(searchWithIndexOf(source_1, 'nodejs')).toEqual([[0, 5]])
+		expect(searchWithIndexOf(source_1, 'nodejs ')).toEqual([[0, 6]])
+		expect(searchWithIndexOf(source_1, 'nodejs  ')).toEqual(0)
+		expect(searchWithIndexOf(source_1, 'js12bss')).toEqual(0)
 	})
 })

--- a/packages/text-search-engine/src/__test__/search.spec.ts
+++ b/packages/text-search-engine/src/__test__/search.spec.ts
@@ -1,6 +1,6 @@
 import { extractBoundaryMapping } from '../boundary'
 import { search } from '../exports'
-import { searchByBoundaryMapping } from '../search'
+import { searchByBoundaryMapping, searchWithIndexof } from '../search'
 
 describe('search', () => {
 	test('searchByBoundaryMapping should work', () => {
@@ -99,5 +99,13 @@ describe('search', () => {
 		])
 
 		expect(search(source_1, 'nozjk', { strictnessCoefficient: 0.4 })).toEqual(undefined)
+	})
+
+	test('searchWithIndexof should work', () => {
+		const source_1 = 'nodejs 123ab ss'
+		expect(searchWithIndexof(source_1, 'nodejs')).toEqual([[0, 5]])
+		expect(searchWithIndexof(source_1, 'nodejs ')).toEqual([[0, 6]])
+		expect(searchWithIndexof(source_1, 'nodejs  ')).toEqual(0)
+		expect(searchWithIndexof(source_1, 'js12bss')).toEqual(0)
 	})
 })

--- a/packages/text-search-engine/src/search.ts
+++ b/packages/text-search-engine/src/search.ts
@@ -145,7 +145,7 @@ export function searchByBoundaryMapping(data: SourceMappingData, target: string,
  */
 export function searchSentenceByBoundaryMapping(boundaryMapping: SourceMappingData, sentence: string) {
 	if (!sentence) return undefined
-	const hitRangesByIndexOf = searchWithIndexof(boundaryMapping.originalString, sentence)
+	const hitRangesByIndexOf = searchWithIndexOf(boundaryMapping.originalString, sentence)
 	if (hitRangesByIndexOf) return hitRangesByIndexOf
 
 	// if target include space characters, we should split it first and then iterate it one by one.
@@ -169,13 +169,13 @@ export function searchSentenceByBoundaryMapping(boundaryMapping: SourceMappingDa
 	return hitRanges.sort((a, b) => a[0] - b[0])
 }
 
-export function searchWithIndexof(source: string, target: string) {
+export function searchWithIndexOf(source: string, target: string) {
 	const startIndex = source.indexOf(target)
 	return ~startIndex && ([[startIndex, startIndex + target.length - 1]] as Matrix)
 }
 
 export function searchEntry(source: string, target: string, getBoundaryMapping: (source: string) => SourceMappingData) {
-	return searchWithIndexof(source, target) || searchSentenceByBoundaryMapping(getBoundaryMapping(source), target)
+	return searchWithIndexOf(source, target) || searchSentenceByBoundaryMapping(getBoundaryMapping(source), target)
 }
 
 // const originalString = 'nodejs  123ab ss'

--- a/packages/text-search-engine/src/search.ts
+++ b/packages/text-search-engine/src/search.ts
@@ -170,7 +170,7 @@ export function searchSentenceByBoundaryMapping(boundaryMapping: SourceMappingDa
 }
 
 export function searchWithIndexof(source: string, target: string) {
-	const startIndex = source.indexOf(target.trim())
+	const startIndex = source.indexOf(target)
 	return ~startIndex && ([[startIndex, startIndex + target.length - 1]] as Matrix)
 }
 


### PR DESCRIPTION
```js
		const source_1 = 'nodejs 123ab ss'
		expect(searchWithIndexOf(source_1, 'nodejs')).toEqual([[0, 5]])
		expect(searchWithIndexOf(source_1, 'nodejs ')).toEqual([[0, 6]])
		expect(searchWithIndexOf(source_1, 'nodejs  ')).toEqual(0)
		expect(searchWithIndexOf(source_1, 'js12bss')).toEqual(0)
```