### PR TITLE
perf(text-search-engine): reduce search DP traversals

### DIFF
--- a/.changeset/calm-searches-move.md
+++ b/.changeset/calm-searches-move.md
@@ -1,0 +1,6 @@
+---
+"text-search-engine": patch
+---
+
+perf: reduce search DP traversals with suffix-aware pruning
+perf: 通过后缀可行边界剪枝减少搜索动态规划遍历

--- a/packages/text-search-engine/src/__test__/search.spec.ts
+++ b/packages/text-search-engine/src/__test__/search.spec.ts
@@ -1,6 +1,6 @@
 import { extractBoundaryMapping } from '../boundary'
 import { search } from '../exports'
-import { searchByBoundaryMapping, searchWithIndexOf } from '../search'
+import { searchByBoundaryMapping, searchSentenceByBoundaryMapping, searchWithIndexOf } from '../search'
 
 describe('search', () => {
 	test('searchByBoundaryMapping should work', () => {
@@ -9,6 +9,85 @@ describe('search', () => {
 		const mappingData = extractBoundaryMapping(source)
 		const range = searchByBoundaryMapping(mappingData, target, 0, source.length)
 		expect(range).toEqual([[0, 1]])
+	})
+
+	test('single-letter search should return the first valid character or pinyin initial', () => {
+		const source = 'zz 的行 xx'
+		const mappingData = extractBoundaryMapping(source, {
+			的: ['de', 'di'],
+			行: ['xing', 'hang'],
+		})
+
+		expect(searchByBoundaryMapping(mappingData, 'd', 3, 5)).toEqual([[3, 3]])
+		expect(searchByBoundaryMapping(mappingData, 'h', 3, 5)).toEqual([[4, 4]])
+		// 'i' only appears inside pinyin and is not a valid first-letter match.
+		expect(searchByBoundaryMapping(mappingData, 'i', 3, 5)).toBeUndefined()
+	})
+
+	test('bounded DP search should preserve long-tail and repeated-character results', () => {
+		expect(search(`a_b_c_d_e_f${'x'.repeat(1_000)}`, 'abcdef')).toEqual([
+			[0, 0],
+			[2, 2],
+			[4, 4],
+			[6, 6],
+			[8, 8],
+			[10, 10],
+		])
+		expect(search('abababab', 'aaaa')).toEqual([
+			[0, 0],
+			[2, 2],
+			[4, 4],
+			[6, 6],
+		])
+		expect(search(`zxhxo zhx${'q'.repeat(1_000)}`, 'zho')).toEqual([
+			[0, 0],
+			[2, 2],
+			[4, 4],
+		])
+	})
+
+	test('bounded DP search should preserve multi-word and partial-range results', () => {
+		const source = `zxhxo zhx 监控${'q'.repeat(1_000)}`
+		const mappingData = extractBoundaryMapping(source, {
+			监: ['jian'],
+			控: ['kong'],
+		})
+
+		expect(searchByBoundaryMapping(mappingData, 'zho', 0, 10)).toEqual([
+			[0, 0],
+			[2, 2],
+			[4, 4],
+		])
+		expect(searchSentenceByBoundaryMapping(mappingData, 'zho jk')).toEqual({
+			hitRanges: [
+				[0, 0],
+				[2, 2],
+				[4, 4],
+				[10, 11],
+			],
+			wordHitRangesMapping: {
+				0: [
+					[0, 0],
+					[2, 2],
+					[4, 4],
+				],
+				1: [[10, 11]],
+			},
+		})
+	})
+
+	test('fuzzy fallback should only check indexOf once', () => {
+		const indexOfSpy = jest.spyOn(String.prototype, 'indexOf')
+		indexOfSpy.mockClear()
+		const result = search('a_b', 'ab')
+		const indexOfCallCount = indexOfSpy.mock.calls.length
+		indexOfSpy.mockRestore()
+
+		expect(result).toEqual([
+			[0, 0],
+			[2, 2],
+		])
+		expect(indexOfCallCount).toBe(1)
 	})
 
 	test('search should work with pure latin', () => {

--- a/packages/text-search-engine/src/search.ts
+++ b/packages/text-search-engine/src/search.ts
@@ -24,6 +24,19 @@ export function searchByBoundaryMapping(data: SourceMappingData, target: string,
 	const startBoundary = boundary[1][0]
 	const endBoundary = boundary[1][1]
 
+	// A single target letter always scores 1, so the first valid word or pinyin initial is optimal.
+	if (targetLength === 1) {
+		for (let i = 0; i < pinyinLength; i++) {
+			const pinyinIndex = i + 1
+			const isNewWord = i === boundary[pinyinIndex][1] - endBoundary
+			if (pinyinString[i] === target && isNewWord) {
+				const originalStringIndex = boundary[pinyinIndex][0] - startBoundary + startIndex
+				return [[originalStringIndex, originalStringIndex]] as Matrix
+			}
+		}
+		return undefined
+	}
+
 	// 输入字符与还原出来的拼音及英文匹配位置，便于直接从首个匹配位置开始遍历：
 	// source：你ni好hao target: h => 命中'好h'，下标跳过'你ni'
 	const matchLetterPositions: number[] = Array(targetLength).fill(-1)
@@ -39,6 +52,20 @@ export function searchByBoundaryMapping(data: SourceMappingData, target: string,
 	// it would be invalid if the input character is smaller than the matched character
 	if (targetMatchLetterCount < targetLength) return undefined
 
+	// Find the latest position of every target letter that still leaves enough source for the remaining suffix.
+	// DP row i only needs to reach the predecessor of latestMatchLetterPositions[i + 1].
+	const latestMatchLetterPositions: number[] = Array(targetLength).fill(-1)
+	let latestTargetIndex = targetLength - 1
+	for (let i = pinyinLength - 1; i >= 0 && latestTargetIndex >= 0; i--) {
+		if (pinyinString[i] === target[latestTargetIndex]) {
+			latestMatchLetterPositions[latestTargetIndex--] = i
+		}
+	}
+
+	// 1-based index used by the DP table. No row can contribute after the final target letter's latest position.
+	let finalDpIndex = latestMatchLetterPositions[targetLength - 1] + 1
+	const dpTableLength = finalDpIndex + 1
+
 	const defaultDpTableValue = [0, 0, -1, -1]
 
 	/**
@@ -49,11 +76,11 @@ export function searchByBoundaryMapping(data: SourceMappingData, target: string,
 	// x你 => x你ni target = ni
 	// n => [1, 1, xx, xx] i => [1, 2, xx, xx]
 	// dpTable：[匹配字符数（包括中文）, 匹配字母数（包括拼音和英文）, 边界开始, 边界结束] 字符包括中文，字母仅包括英文
-	const dpTable = Array.from({ length: pinyinLength + 1 }, () => defaultDpTableValue)
+	const dpTable = Array.from({ length: dpTableLength }, () => defaultDpTableValue)
 	// 每个下标的得分，每一轮都会更新
-	const dpScores: number[] = Array(pinyinLength + 1).fill(0)
+	const dpScores: number[] = Array(dpTableLength).fill(0)
 	// dpMatchPath: [start：匹配开始的原文字符下标, end：匹配结束的原文字符下标, matchedLetters：匹配的字母个数]
-	const dpMatchPath: [number, number, number][][] = Array.from({ length: pinyinLength + 1 }, () => Array(targetLength))
+	const dpMatchPath: [number, number, number][][] = Array.from({ length: dpTableLength }, () => Array(targetLength))
 
 	// 遍历次数统计
 
@@ -63,6 +90,10 @@ export function searchByBoundaryMapping(data: SourceMappingData, target: string,
 		// we need to check for null. Therefore, index uniformly start from 1.
 		// 在
 		let matchedPinyinIndex = matchLetterPositions[matchIndex] + 1
+		const rowEndIndex =
+			matchIndex === targetLength - 1
+				? latestMatchLetterPositions[matchIndex] + 1
+				: latestMatchLetterPositions[matchIndex + 1]
 
 		debugFn(() => {
 			console.log('outer for letter:', pinyinString[matchedPinyinIndex - 1], 'matchedPinyinIndex', matchedPinyinIndex)
@@ -81,7 +112,7 @@ export function searchByBoundaryMapping(data: SourceMappingData, target: string,
 
 		// 标记是否找到当前字符的有效匹配
 		let foundValidMatchForCurrentChar = false
-		for (; matchedPinyinIndex <= pinyinLength; matchedPinyinIndex++) {
+		for (; matchedPinyinIndex <= rowEndIndex; matchedPinyinIndex++) {
 			debugFn(() => {
 				totalLoopCount++
 				console.log('inner for letter:', pinyinString[matchedPinyinIndex - 1])
@@ -141,6 +172,12 @@ export function searchByBoundaryMapping(data: SourceMappingData, target: string,
 					// 当前字符遍历一遍，如果都没有进入当前 if 分支说明没有匹配到，在外层即可 return
 					// issue: https://github.com/cjinhuo/text-search-engine/issues/21
 					foundValidMatchForCurrentChar = true
+					// The maximum score for N letters is 1 + 3 + ... + (2N - 1) = N².
+					// Later matches cannot improve it, and equal scores keep the earlier path.
+					if (matchIndex === targetLength - 1 && computedScore === targetLength * targetLength) {
+						finalDpIndex = matchedPinyinIndex
+						break
+					}
 					continue
 				}
 			}
@@ -170,10 +207,10 @@ export function searchByBoundaryMapping(data: SourceMappingData, target: string,
 		console.log(`total loop count: ${totalLoopCount}`)
 	})
 
-	if (dpMatchPath[pinyinLength][targetLength - 1] === undefined) return undefined
+	if (dpMatchPath[finalDpIndex][targetLength - 1] === undefined) return undefined
 	const hitIndices: Matrix = []
 	// 从后往前遍历 dpMatchPath，记录未匹配拼音字符的下标
-	let backtrackPinyinIndex = pinyinLength
+	let backtrackPinyinIndex = finalDpIndex
 	// 剩余待匹配的 target 字符下标（数量）
 	let remainingTargetIndex = targetLength - 1
 
@@ -207,6 +244,14 @@ export function searchByBoundaryMapping(data: SourceMappingData, target: string,
  * @param sentence the target sentence
  */
 export function searchSentenceByBoundaryMapping(boundaryMapping: SourceMappingData, sentence: string) {
+	return searchSentenceByBoundaryMappingInternal(boundaryMapping, sentence, true)
+}
+
+function searchSentenceByBoundaryMappingInternal(
+	boundaryMapping: SourceMappingData,
+	sentence: string,
+	shouldSearchWithIndexOf: boolean
+) {
 	const wordHitRangesMapping: Record<number, Matrix> = {}
 	if (!sentence) {
 		return {
@@ -214,12 +259,14 @@ export function searchSentenceByBoundaryMapping(boundaryMapping: SourceMappingDa
 			wordHitRangesMapping,
 		}
 	}
-	const hitRangesByIndexOf = searchWithIndexOf(boundaryMapping.originalString, sentence)
-	if (hitRangesByIndexOf)
-		return {
-			hitRanges: hitRangesByIndexOf,
-			wordHitRangesMapping,
-		}
+	if (shouldSearchWithIndexOf) {
+		const hitRangesByIndexOf = searchWithIndexOf(boundaryMapping.originalString, sentence)
+		if (hitRangesByIndexOf)
+			return {
+				hitRanges: hitRangesByIndexOf,
+				wordHitRangesMapping,
+			}
+	}
 	// if target include space characters, we should split it first and then iterate it one by one.
 	const words = sentence.trim().split(/\s+/)
 	const hitRanges: Matrix = []
@@ -272,7 +319,11 @@ export function searchEntry(source: string, target: string, getBoundaryMapping: 
 			wordHitRangesMapping: {},
 		}
 	}
-	const { hitRanges, wordHitRangesMapping } = searchSentenceByBoundaryMapping(getBoundaryMapping(source), target)
+	const { hitRanges, wordHitRangesMapping } = searchSentenceByBoundaryMappingInternal(
+		getBoundaryMapping(source),
+		target,
+		false
+	)
 	return {
 		rawHitRanges: hitRanges,
 		wordHitRangesMapping,


### PR DESCRIPTION
## Summary

- add a single-letter fast path for original-character and pinyin-initial matches
- bound each dynamic-programming row with the latest suffix-feasible position
- limit DP allocation to the reachable window and stop when the theoretical maximum score is reached
- avoid the duplicate `indexOf` scan on fuzzy-search fallback
- add focused coverage for long tails, repeated characters, polyphonic pinyin, partial ranges, and multi-word search

## Why

Each target character previously scanned from its earliest match position to the end of the expanded pinyin string. Positions that could no longer complete the remaining query suffix still propagated DP state, creating unnecessary traversal and allocation work.

## Impact

Public APIs, scoring, tie-breaking, hit ranges, and reusable `boundaryData` behavior remain unchanged. Worst-case complexity remains `O(M × N)`.

Measured DP inner-loop reductions:

- long-tail fuzzy match: 60,036 → 11 (99.98%)
- pinyin long tail: 55,017 → 11,004 (80.00%)
- backtracking long tail: 30,021 → 5 (99.98%)
- dense repeated input: 134,892 → 134,782 (no regression)

## Validation

- 132,760 fixed-seed differential cases matched the previous implementation exactly
- `pnpm --filter text-search-engine test` — 65/65 tests passed
- `pnpm --filter text-search-engine build` — TypeScript and Rollup builds passed
- `git diff --check` passed