### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Feel free to join the fun and send a PR!
 
 [![Contributors](https://contrib.rocks/image?repo=cjinhuo/text-search-engine)](https://github.com/cjinhuo/text-search-engine/graphs/contributors)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cjinhuo/text-search-engine&type=Date)](https://api.star-history.com/svg?repos=cjinhuo/text-search-engine&type=Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cjinhuo/text-search-engine&type=date)](https://star-history.dera.page/#cjinhuo/text-search-engine&type=date)
 
 
 

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -161,7 +161,7 @@ export default function DemoForHighlightWithTarget() {
 
 [![Contributors](https://contrib.rocks/image?repo=cjinhuo/text-search-engine)](https://github.com/cjinhuo/text-search-engine/graphs/contributors)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cjinhuo/text-search-engine&type=Date)](https://api.star-history.com/svg?repos=cjinhuo/text-search-engine&type=Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cjinhuo/text-search-engine&type=date)](https://star-history.dera.page/#cjinhuo/text-search-engine&type=date)
 
 # 📞 联系
 欢迎提 issue，你可以加我微信或者邮件联系我，如果你有好的建议(备注：text-search-engine)


### PR DESCRIPTION
The star history chart in the README is broken. GitHub's stargazer API restriction made the original chart unusable, so it no longer renders on the project page. This PR updates the chart link in the README and the Chinese translation to a working alternative so the chart shows up again.

This is a documentation-only change, please take a look.